### PR TITLE
fix: remove layout prop as it was discontinued from Next.js 13 on

### DIFF
--- a/src/stories/Configure.mdx
+++ b/src/stories/Configure.mdx
@@ -221,7 +221,6 @@ export const RightArrow = () => <svg
       <Image 
         width={32}
         height={32}
-        layout="fixed"
         src={Github} 
         alt="Github logo" 
         className="sb-explore-image"
@@ -237,7 +236,6 @@ export const RightArrow = () => <svg
       <Image 
         width={33}
         height={32}
-        layout="fixed"
         src={Discord} 
         alt="Discord logo" 
         className="sb-explore-image"
@@ -255,7 +253,6 @@ export const RightArrow = () => <svg
       <Image 
         width={32}
         height={32}
-        layout="fixed"
         src={Youtube} 
         alt="Youtube logo" 
         className="sb-explore-image"
@@ -273,7 +270,6 @@ export const RightArrow = () => <svg
       <Image 
         width={33}
         height={32}
-        layout="fixed"
         src={Tutorials} 
         alt="A book" 
         className="sb-explore-image"


### PR DESCRIPTION
- Referenced the Next.js documentation on upgrading to version 13 for the image component: [Next.js 13 Upgrade](https://nextjs.org/docs/messages/next-image-upgrade-to-13).
- I wasn't able to find any errors, so the issue mentioned:

  > Uncaught (in promise) TypeError: No existing state found for follower with id: 'storybook/test'. Make sure a leader with the same id exists before creating a follower. at globals-runtime.js:25631:9
  
  possibly requires more information to reproduce and investigate further.